### PR TITLE
Correcion de bug en people#index, se pasa el id de person no el de user

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -12,7 +12,7 @@ class PeopleController < ApplicationController
   end
 
   def show
-    person = Person.find(params[:id])
+    person = Person.find_by(id: params[:id])
 
     if person
       #nombre


### PR DESCRIPTION
No contiene ninguna historia, solo corrige un pequeño bug en people#index no mostraba bien el perfil cuando el id del usuario no coincidía con el id de la persona. Hay que obtener el user y pasar user.person_id.
